### PR TITLE
detect and emit sdl.SDL_SetVideoMode initialization errors

### DIFF
--- a/ffi/SDL.lua
+++ b/ffi/SDL.lua
@@ -1798,6 +1798,10 @@ ffi.cdef[[
    void     SDL_TimerQuit(             );
    int      SDL_HelperWindowCreate(    );
    int      SDL_HelperWindowDestroy(   );
+
+   void     SDL_SetError(const char *fmt, ...);
+   char*    SDL_GetError(void);
+   void     SDL_ClearError(void);
 ]]
 
 return sdl

--- a/lib/wm/sdl.lua
+++ b/lib/wm/sdl.lua
@@ -71,6 +71,7 @@ local function init(self, width, height)
       self.width, self.height, 32,
       bit.bor( sdl.SDL_DOUBLEBUF*0, sdl.SDL_RESIZABLE )
    )
+   assert(NULL ~= self.window, ffi.string(sdl.SDL_GetError()))
    self.event = ffi.new( "SDL_Event" )
    self.event.type, self.event.resize.w, self.event.resize.h = sdl.SDL_VIDEORESIZE, self.width, self.height
    sdl.SDL_PushEvent( self.event )


### PR DESCRIPTION
before: 
`ubuntu@ubuntu:~/ufo$ env DISPLAY= ./luajit samples/intro.lua
     ./luajit: line 62: 27248 Segmentation fault      (core dumped) "$progname/bin/$OSARCH/luajit" "$@"`

after:
`ubuntu@ubuntu:~/ufo$ env DISPLAY= ./luajit samples/intro.lua
./bin/Linux/x86/luajit: /home/ubuntu/ufo/lib/wm/sdl.lua:74: No available video device
stack traceback:
    [C]: in function 'assert'
    /home/ubuntu/ufo/lib/wm/sdl.lua:74: in function 'init'
    /home/ubuntu/ufo/lib/wm/sdl.lua:20: in function 'update'
    samples/intro.lua:31: in main chunk
    [C]: ?`
